### PR TITLE
ホーム画面にアカウント削除ボタンを追加・ログアウトバグ修正・CI更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,18 @@ jobs:
           ruby-version: .ruby-version
           bundler-cache: true
 
+      - name: Node.js のセットアップ
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
+
+      - name: npm パッケージのインストール
+        run: yarn install --frozen-lockfile
+
+      - name: CSS のビルド
+        run: yarn build:css
+
       - name: データベースのセットアップ
         run: bundle exec rails db:create db:migrate RAILS_ENV=test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - uses: actions/checkout@v4

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -16,11 +16,19 @@
           <p class="card-text text-muted mb-3">
             <i class="bi bi-envelope me-1"></i><%= current_user.email %>
           </p>
-          <%= link_to destroy_user_session_path,
-                class: 'btn btn-outline-danger px-4',
-                data: { turbo_method: :delete } do %>
-            <i class="bi bi-box-arrow-right me-1"></i>ログアウト
-          <% end %>
+          <div class="d-flex justify-content-center gap-2 flex-wrap">
+            <%= button_to destroy_user_session_path,
+                  method: :delete,
+                  class: 'btn btn-outline-danger px-4' do %>
+              <i class="bi bi-box-arrow-right me-1"></i>ログアウト
+            <% end %>
+            <%= button_to user_registration_path,
+                  method: :delete,
+                  class: 'btn btn-danger px-4',
+                  data: { turbo_confirm: '本当にアカウントを削除しますか？この操作は元に戻せません。' } do %>
+              <i class="bi bi-trash me-1"></i>アカウント削除
+            <% end %>
+          </div>
         </div>
       </div>
     </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,9 +18,9 @@
             <span class="navbar-text text-white me-3">
               <i class="bi bi-person-circle me-1"></i><%= current_user.email %>
             </span>
-            <%= link_to destroy_user_session_path,
-                  class: 'btn btn-outline-light btn-sm',
-                  data: { turbo_method: :delete } do %>
+            <%= button_to destroy_user_session_path,
+                  method: :delete,
+                  class: 'btn btn-outline-light btn-sm' do %>
               <i class="bi bi-box-arrow-right me-1"></i>ログアウト
             <% end %>
           <% else %>

--- a/spec/requests/users/registrations_spec.rb
+++ b/spec/requests/users/registrations_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe "Users::Registrations", type: :request do
+  include Warden::Test::Helpers
+
+  after { Warden.test_reset! }
+
+  let(:user) do
+    u = User.create!(email: 'test@example.com', password: 'password123', password_confirmation: 'password123')
+    u.confirm
+    u
+  end
+
+  describe "DELETE /users (アカウント削除)" do
+    context "ログイン済みユーザーの場合" do
+      before { login_as user, scope: :user }
+
+      it "自分のアカウントを削除できる（リダイレクトされる）" do
+        delete user_registration_path
+        expect(response).to have_http_status(:see_other)
+      end
+
+      it "DBからユーザーレコードが削除される" do
+        user_id = user.id
+        delete user_registration_path
+        expect(User.exists?(user_id)).to be false
+      end
+
+      it "削除後はトップページへリダイレクトされる" do
+        delete user_registration_path
+        expect(response).to redirect_to(root_path)
+      end
+
+      it "削除後にログインしようとしても失敗する" do
+        email = user.email
+        delete user_registration_path
+        post user_session_path, params: { user: { email: email, password: 'password123' } }
+        expect(response).not_to redirect_to(root_path)
+      end
+    end
+
+    context "未ログインの場合" do
+      it "削除できずサインインページへリダイレクトされる" do
+        delete user_registration_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
 ## 概要

  ホーム画面にアカウント削除ボタンを追加し、ログアウト時の Routing Error を修正しました。あわせて GitHub Actions の
  Node.js deprecation 警告に対応しています。

  ## 変更内容

  **ホーム画面**
  - ログイン中カードにアカウント削除ボタンを追加（確認ダイアログ付き）
  - ログアウト・削除ボタンを横並びで表示

  **バグ修正**
  - ログアウトボタンを `link_to + data-turbo-method` から `button_to method: :delete` に変更
    - Turbo JS 未導入のため GET リクエストになり Routing Error が発生していた問題を解消

  **CI**
  - `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` を設定し Node.js 24 に移行
    - 2026年6月2日以降の Node.js 20 強制廃止に先立って対応